### PR TITLE
parallel userops execution examples added

### DIFF
--- a/backend-node/scripts/erc20/parallelUserOpsMintNFT.ts
+++ b/backend-node/scripts/erc20/parallelUserOpsMintNFT.ts
@@ -195,14 +195,19 @@ export const parallelUserOpsMintNFTPayERC20 = async () => {
   // and also send the full op to attached bundler instance
 
   try {
-    let userOpResponses = [];
+    let userOpResponsePromises = [];
+    /**
+     * Will shuffle userOps here based on a random logic and send them randomly
+     */
+    const shuffledPartialUserOps = partialUserOps.sort(() => Math.random() - 0.5);
     for (let index = 0; index < numOfParallelUserOps; index++) {
-      console.log(chalk.blue(`userOp: ${JSON.stringify(finalUserOps[index], null, "\t")}`));
-      console.log(chalk.blue(`userOp nonce being sent to bundler: ${JSON.stringify(Number(partialUserOps[index].nonce), null, "\t")}`))
-      const userOpResponse = await biconomySmartAccount.sendUserOp(finalUserOps[index]);
-      console.log(chalk.green(`userOp Hash: ${userOpResponse.userOpHash}`));
-      userOpResponses.push(userOpResponse);
+      console.log(chalk.blue(`userOp: ${JSON.stringify(shuffledPartialUserOps[index], null, "\t")}`));
+      console.log(chalk.blue(`userOp nonce being sent to bundler: ${JSON.stringify(Number(shuffledPartialUserOps[index].nonce), null, "\t")}`))
+      const userOpResponsePromise = biconomySmartAccount.sendUserOp(shuffledPartialUserOps[index]);
+      userOpResponsePromises.push(userOpResponsePromise)
     }
+
+    const userOpResponses = await Promise.all(userOpResponsePromises);
 
     for (let index = 0; index < numOfParallelUserOps; index++) {
       const transactionDetails = await userOpResponses[index].wait();

--- a/backend-node/scripts/erc20/parallelUserOpsMintNFT.ts
+++ b/backend-node/scripts/erc20/parallelUserOpsMintNFT.ts
@@ -1,0 +1,218 @@
+import { ethers } from "ethers";
+const chalk = require('chalk')
+import inquirer from "inquirer";
+import {
+  BiconomySmartAccountV2,
+  DEFAULT_ENTRYPOINT_ADDRESS,
+} from "@biconomy/account";
+  import { Bundler } from "@biconomy/bundler";
+  import { BiconomyPaymaster } from "@biconomy/paymaster";
+import {
+  IHybridPaymaster,
+  PaymasterFeeQuote,
+  PaymasterMode,
+  SponsorUserOperationDto,
+} from "@biconomy/paymaster";
+import config from "../../config.json";
+import { ECDSAOwnershipValidationModule, MultiChainValidationModule, DEFAULT_ECDSA_OWNERSHIP_MODULE, DEFAULT_MULTICHAIN_MODULE, DEFAULT_SESSION_KEY_MANAGER_MODULE  } from "@biconomy/modules";
+import { UserOperation } from "@biconomy/core-types";
+
+const numOfParallelUserOps = 3;
+
+export const parallelUserOpsMintNFTPayERC20 = async () => {
+  // ------------------------STEP 1: Initialise Biconomy Smart Account SDK--------------------------------//  
+
+
+
+  // get EOA address from wallet provider
+  let provider = new ethers.providers.JsonRpcProvider(config.rpcUrl);
+  let signer = new ethers.Wallet(config.privateKey, provider);
+  const eoa = await signer.getAddress();
+  console.log(chalk.blue(`EOA address: ${eoa}`));
+
+  // create bundler and paymaster instances
+  const bundler = new Bundler({
+    bundlerUrl: config.bundlerUrl,
+    chainId: config.chainId,
+    entryPointAddress: DEFAULT_ENTRYPOINT_ADDRESS,
+  });
+
+  const paymaster = new BiconomyPaymaster({
+    paymasterUrl: config.biconomyPaymasterUrl
+  });
+
+  const ecdsaModule = await ECDSAOwnershipValidationModule.create({
+    signer: signer,
+    moduleAddress: DEFAULT_ECDSA_OWNERSHIP_MODULE
+  })
+
+  // Biconomy smart account config
+  // Note that paymaster and bundler are optional. You can choose to create new instances of this later and make account API use 
+  const biconomySmartAccountConfig = {
+    signer: signer,
+    chainId: config.chainId,
+    rpcUrl: config.rpcUrl,
+    paymaster: paymaster, 
+    bundler: bundler, 
+    entryPointAddress: DEFAULT_ENTRYPOINT_ADDRESS,
+    defaultValidationModule: ecdsaModule,
+    activeValidationModule: ecdsaModule
+  };
+
+  // create biconomy smart account instance
+  const biconomySmartAccount = await BiconomySmartAccountV2.create(biconomySmartAccountConfig);
+
+  
+  // ------------------------STEP 2: Build Partial User op from your user Transaction/s Request --------------------------------//
+
+  // generate mintNft data
+  const nftInterface = new ethers.utils.Interface([
+    "function safeMint(address _to)",
+  ]);
+
+ 
+  const scwAddress = await biconomySmartAccount.getAccountAddress();
+
+  // Here we are minting NFT to smart account address itself
+  const data = nftInterface.encodeFunctionData("safeMint", [scwAddress]);
+
+  const nftAddress = "0x1758f42Af7026fBbB559Dc60EcE0De3ef81f665e"; // Todo // use from config
+  const transaction = {
+    to: nftAddress,
+    data: data,
+  };
+
+  let partialUserOps = [];
+  let finalUserOps = [];
+
+  // use a nonceKey that is unique
+  // easy way is to increment the nonceKey
+
+  for (let nonceKey = 0; nonceKey < numOfParallelUserOps; nonceKey++) {
+    // build partial userOp 
+    let partialUserOp = await biconomySmartAccount.buildUserOp([transaction], { nonceOptions: { nonceKey }});
+    partialUserOps.push(partialUserOp);
+  }
+
+
+  // ------------------------STEP 3: Get Fee quotes (for ERC20 payment) from the paymaster and ask the user to select one--------------------------------//
+
+  const biconomyPaymaster =
+    biconomySmartAccount.paymaster as IHybridPaymaster<SponsorUserOperationDto>;
+
+  for (let index = 0; index < numOfParallelUserOps; index++) {
+    const feeQuotesResponse =
+    await biconomyPaymaster.getPaymasterFeeQuotesOrData(partialUserOps[index], {
+      // here we are explicitly telling by mode ERC20 that we want to pay in ERC20 tokens and expect fee quotes
+      mode: PaymasterMode.ERC20,
+      // one can pass tokenList empty array. and it would return fee quotes for all tokens supported by the Biconomy paymaster
+      tokenList: config.tokenList ? config.tokenList : [],
+      // preferredToken is optional. If you want to pay in a specific token, you can pass its address here and get fee quotes for that token only
+      preferredToken: config.preferredToken,
+    });
+
+    const feeQuotes = feeQuotesResponse.feeQuotes as PaymasterFeeQuote[];
+    const spender = feeQuotesResponse.tokenPaymasterAddress || "";
+
+
+    // Generate list of options for the user to select
+    const choices = feeQuotes?.map((quote: any, index: number) => ({
+        name: `Option ${index + 1}: ${quote.maxGasFee}: ${quote.symbol} `,
+        value: index,
+      }));
+    // Use inquirer to prompt user to select an option
+    const { selectedOption } = await inquirer.prompt([
+        {
+          type: "list",
+          name: "selectedOption",
+          message: "Select a fee quote:",
+          choices,
+        },
+      ]);
+    const selectedFeeQuote = feeQuotes[selectedOption];
+
+
+
+    // ------------------------STEP 3: Once you have selected feeQuote (use has chosen token to pay with) get updated userOp which checks for paymaster approval and appends approval tx--------------------------------//
+      
+
+    let finalUserOp = await biconomySmartAccount.buildTokenPaymasterUserOp(
+      partialUserOps[index],
+      {
+        feeQuote: selectedFeeQuote,
+        spender: spender,
+        maxApproval: false,
+      }
+    );
+    // ------------------------STEP 4: Get Paymaster and Data from Biconomy Paymaster --------------------------------//  
+
+
+    let paymasterServiceData = {
+      mode: PaymasterMode.ERC20, // - mandatory // now we know chosen fee token and requesting paymaster and data for it
+      feeTokenAddress: selectedFeeQuote.tokenAddress,
+      // optional params..
+      calculateGasLimits: true, // Always recommended and especially when using token paymaster
+    };
+
+    try{
+      const paymasterAndDataWithLimits =
+        await biconomyPaymaster.getPaymasterAndData(
+          finalUserOp,
+          paymasterServiceData
+        );
+      finalUserOp.paymasterAndData = paymasterAndDataWithLimits.paymasterAndData;
+
+      // below code is only needed if you sent the flag calculateGasLimits = true
+      if (
+        paymasterAndDataWithLimits.callGasLimit &&
+        paymasterAndDataWithLimits.verificationGasLimit &&
+        paymasterAndDataWithLimits.preVerificationGas
+      ) {
+
+        // Returned gas limits must be replaced in your op as you update paymasterAndData.
+        // Because these are the limits paymaster service signed on to generate paymasterAndData
+        // If you receive AA34 error check here..   
+
+        finalUserOp.callGasLimit = paymasterAndDataWithLimits.callGasLimit;
+        finalUserOp.verificationGasLimit =
+          paymasterAndDataWithLimits.verificationGasLimit;
+        finalUserOp.preVerificationGas =
+          paymasterAndDataWithLimits.preVerificationGas;
+      }
+      finalUserOps.push(finalUserOp);
+    } catch (e) {
+      console.log("error received ", e);
+    }
+  }
+
+
+  // ------------------------STEP 5: Sign the UserOp and send to the Bundler--------------------------------//
+
+
+
+
+  // Below function gets the signature from the user (signer provided in Biconomy Smart Account) 
+  // and also send the full op to attached bundler instance
+
+  try {
+    let userOpResponses = [];
+    for (let index = 0; index < numOfParallelUserOps; index++) {
+      console.log(chalk.blue(`userOp: ${JSON.stringify(finalUserOps[index], null, "\t")}`));
+      console.log(chalk.blue(`userOp nonce being sent to bundler: ${JSON.stringify(Number(partialUserOps[index].nonce), null, "\t")}`))
+      const userOpResponse = await biconomySmartAccount.sendUserOp(finalUserOps[index]);
+      console.log(chalk.green(`userOp Hash: ${userOpResponse.userOpHash}`));
+      userOpResponses.push(userOpResponse);
+    }
+
+    for (let index = 0; index < numOfParallelUserOps; index++) {
+      const transactionDetails = await userOpResponses[index].wait();
+      console.log(
+        chalk.blue(
+          `transactionDetails: ${JSON.stringify(transactionDetails, null, "\t")}`
+        )
+      );
+    }
+  } catch (e) {
+    console.log("error received ", e);
+  }
+};

--- a/backend-node/scripts/gasless/parallelUserOpsMintNFT.ts
+++ b/backend-node/scripts/gasless/parallelUserOpsMintNFT.ts
@@ -152,14 +152,19 @@ export const parallelUserOpsMintNft = async () => {
   // and also send the full op to attached bundler instance
 
   try {
-    let userOpResponses = [];
+    let userOpResponsePromises = [];
+    /**
+     * Will shuffle userOps here based on a random logic and send them randomly
+     */
+    const shuffledPartialUserOps = partialUserOps.sort(() => Math.random() - 0.5);
     for (let index = 0; index < numOfParallelUserOps; index++) {
-      console.log(chalk.blue(`userOp: ${JSON.stringify(partialUserOps[index], null, "\t")}`));
-      console.log(chalk.blue(`userOp nonce being sent to bundler: ${JSON.stringify(Number(partialUserOps[index].nonce), null, "\t")}`))
-      const userOpResponse = await biconomySmartAccount.sendUserOp(partialUserOps[index]);
-      console.log(chalk.green(`userOp Hash: ${userOpResponse.userOpHash}`));
-      userOpResponses.push(userOpResponse)
+      console.log(chalk.blue(`userOp: ${JSON.stringify(shuffledPartialUserOps[index], null, "\t")}`));
+      console.log(chalk.blue(`userOp nonce being sent to bundler: ${JSON.stringify(Number(shuffledPartialUserOps[index].nonce), null, "\t")}`))
+      const userOpResponsePromise = biconomySmartAccount.sendUserOp(shuffledPartialUserOps[index]);
+      userOpResponsePromises.push(userOpResponsePromise)
     }
+
+    const userOpResponses = await Promise.all(userOpResponsePromises);
 
     for (let index = 0; index < numOfParallelUserOps; index++) {
       const transactionDetails = await userOpResponses[index].wait();

--- a/backend-node/scripts/gasless/parallelUserOpsMintNFT.ts
+++ b/backend-node/scripts/gasless/parallelUserOpsMintNFT.ts
@@ -1,0 +1,188 @@
+import { ethers } from "ethers";
+const chalk = require('chalk')
+
+import {
+    BiconomySmartAccountV2,
+    DEFAULT_ENTRYPOINT_ADDRESS,
+  } from "@biconomy/account";
+  import { Bundler } from "@biconomy/bundler";
+  import { BiconomyPaymaster } from "@biconomy/paymaster";
+import {
+  IHybridPaymaster,
+  PaymasterMode,
+  SponsorUserOperationDto,
+} from "@biconomy/paymaster";
+import config from "../../config.json";
+import { ECDSAOwnershipValidationModule, MultiChainValidationModule, DEFAULT_ECDSA_OWNERSHIP_MODULE, DEFAULT_MULTICHAIN_MODULE, DEFAULT_SESSION_KEY_MANAGER_MODULE  } from "@biconomy/modules";
+
+const numOfParallelUserOps = 3;
+
+export const parallelUserOpsMintNft = async () => {
+
+  // ------------------------STEP 1: Initialise Biconomy Smart Account SDK--------------------------------//  
+
+  // get EOA address from wallet provider
+  let provider = new ethers.providers.JsonRpcProvider(config.rpcUrl);
+  let signer = new ethers.Wallet(config.privateKey, provider);
+  const eoa = await signer.getAddress();
+  console.log(chalk.blue(`EOA address: ${eoa}`));
+
+  // create bundler and paymaster instances
+  const bundler = new Bundler({
+    bundlerUrl: config.bundlerUrl,
+    chainId: config.chainId,
+    entryPointAddress: DEFAULT_ENTRYPOINT_ADDRESS,
+  });
+
+  const paymaster = new BiconomyPaymaster({
+    paymasterUrl: config.biconomyPaymasterUrl
+  });
+
+  const ecdsaModule = await ECDSAOwnershipValidationModule.create({
+    signer: signer,
+    moduleAddress: DEFAULT_ECDSA_OWNERSHIP_MODULE
+  })
+
+  // Biconomy smart account config
+  // Note that paymaster and bundler are optional. You can choose to create new instances of this later and make account API use 
+  const biconomySmartAccountConfig = {
+    signer: signer,
+    chainId: config.chainId,
+    rpcUrl: config.rpcUrl,
+    paymaster: paymaster, 
+    bundler: bundler, 
+    entryPointAddress: DEFAULT_ENTRYPOINT_ADDRESS,
+    defaultValidationModule: ecdsaModule,
+    activeValidationModule: ecdsaModule
+  };
+
+  // create biconomy smart account instance
+  const biconomySmartAccount = await BiconomySmartAccountV2.create(biconomySmartAccountConfig);
+
+
+  // ------------------------STEP 2: Build Partial User op from your user Transaction/s Request --------------------------------//
+
+  
+  // mint NFT
+  // Please note that for sponsorship, policies have to be added on the Biconomy dashboard https://dashboard.biconomy.io/
+  // in this case it will be whitelisting NFT contract and method safeMint()
+
+  // 1. for native token transfer no policy is required. you may add a webhook to have custom control over this
+  // 2. If no policies are added every transaction will be sponsored by your paymaster
+  // 3. If you add policies, then only transactions that match the policy will be sponsored by your paymaster
+
+  // generate mintNft data
+  const nftInterface = new ethers.utils.Interface([
+    "function safeMint(address _to)",
+  ]);
+
+
+  const scwAddress = await biconomySmartAccount.getAccountAddress();
+
+  // Here we are minting NFT to smart account address itself
+  const data = nftInterface.encodeFunctionData("safeMint", [scwAddress]);
+
+  const nftAddress = "0x1758f42Af7026fBbB559Dc60EcE0De3ef81f665e"; // Todo // use from config
+  const transaction = {
+    to: nftAddress,
+    data: data,
+  };
+
+  let partialUserOps = []
+
+  // use a nonceKey that is unique
+  // easy way is to increment the nonceKey
+  for (let nonceKey = 0; nonceKey < numOfParallelUserOps; nonceKey++) {
+    // build partial userOp
+    let partialUserOp = await biconomySmartAccount.buildUserOp([transaction], { nonceOptions: { nonceKey }});
+    partialUserOps.push(partialUserOp);
+  }
+
+  // ------------------------STEP 3: Get Paymaster and Data from Biconomy Paymaster --------------------------------//
+
+
+  const biconomyPaymaster =
+    biconomySmartAccount.paymaster as IHybridPaymaster<SponsorUserOperationDto>;
+
+  // Here it is meant to act as Sponsorship/Verifying paymaster hence we send mode: PaymasterMode.SPONSORED which is must  
+  let paymasterServiceData: SponsorUserOperationDto = {
+        mode: PaymasterMode.SPONSORED,
+        smartAccountInfo: {
+          name: 'BICONOMY',
+          version: '2.0.0'
+        },
+        // optional params...
+        calculateGasLimits: true
+    };
+
+  try {
+    for (let index = 0; index < numOfParallelUserOps; index++) {
+      const paymasterAndDataResponse =
+      await biconomyPaymaster.getPaymasterAndData(
+        partialUserOps[index],                                                                                  
+        paymasterServiceData
+      );
+      partialUserOps[index].paymasterAndData = paymasterAndDataResponse.paymasterAndData;
+
+      if (
+        paymasterAndDataResponse.callGasLimit &&
+        paymasterAndDataResponse.verificationGasLimit &&
+        paymasterAndDataResponse.preVerificationGas
+      ) {
+  
+        // Returned gas limits must be replaced in your op as you update paymasterAndData.
+        // Because these are the limits paymaster service signed on to generate paymasterAndData
+        // If you receive AA34 error check here..   
+  
+        partialUserOps[index].callGasLimit = paymasterAndDataResponse.callGasLimit;
+        partialUserOps[index].verificationGasLimit =
+        paymasterAndDataResponse.verificationGasLimit;
+        partialUserOps[index].preVerificationGas =
+        paymasterAndDataResponse.preVerificationGas;
+      }
+    }
+  } catch (e) {
+    console.log("error received ", e);
+  }
+
+  
+  // ------------------------STEP 4: Sign the UserOp and send to the Bundler--------------------------------//
+
+  // Below function gets the signature from the user (signer provided in Biconomy Smart Account) 
+  // and also send the full op to attached bundler instance
+
+  try {
+    let userOpResponses = [];
+    for (let index = 0; index < numOfParallelUserOps; index++) {
+      console.log(chalk.blue(`userOp: ${JSON.stringify(partialUserOps[index], null, "\t")}`));
+      console.log(chalk.blue(`userOp nonce being sent to bundler: ${JSON.stringify(Number(partialUserOps[index].nonce), null, "\t")}`))
+      const userOpResponse = await biconomySmartAccount.sendUserOp(partialUserOps[index]);
+      console.log(chalk.green(`userOp Hash: ${userOpResponse.userOpHash}`));
+      userOpResponses.push(userOpResponse)
+    }
+
+    for (let index = 0; index < numOfParallelUserOps; index++) {
+      const transactionDetails = await userOpResponses[index].wait();
+      console.log(
+        chalk.blue(
+          `transactionDetails: ${JSON.stringify(transactionDetails, null, "\t")}`
+        )
+      );
+    }
+  } catch (e) {
+    console.log("error received ", e);
+  }
+
+  /*try {
+    const userOpResponse = await biconomySmartAccount.enableModule(DEFAULT_SESSION_KEY_MANAGER_MODULE);
+    console.log(chalk.green(`userOp Hash: ${userOpResponse.userOpHash}`));
+    const transactionDetails = await userOpResponse.wait();
+    console.log(
+      chalk.blue(
+        `transactionDetails: ${JSON.stringify(transactionDetails, null, "\t")}`
+      )
+    );
+    } catch (e) {
+      console.log("error received ", e);
+    }*/
+};

--- a/backend-node/scripts/index.ts
+++ b/backend-node/scripts/index.ts
@@ -8,7 +8,9 @@ import { nativeTransferPayERC20 } from "./erc20/nativeTransfer";
 import { erc20Transfer } from "./gasless/erc20Transfer";
 import { erc20TransferPayERC20 } from "./erc20/erc20Transfer";
 import { mintNft } from "./gasless/mintNFT";
+import { parallelUserOpsMintNft } from "./gasless/parallelUserOpsMintNFT.ts"
 import { mintNftPayERC20 } from "./erc20/mintNFT";
+import { parallelUserOpsMintNFTPayERC20 } from './erc20/parallelUserOpsMintNFT.ts';
 import { batchMintNft } from "./gasless/batchMintNFT";
 import { batchMintNftPayERC20 } from "./erc20/batchMintNFT";
 import { batchMintNftTrySponsorshipOtherwisePayERC20 } from "./hybrid-fallback/batchMintNFT";
@@ -153,6 +155,10 @@ yargs
       }
       else if(argv.mode === "HYBRID") {
         mintNftTrySponsorshipOtherwisePayERC20();
+      } else if (argv.mode === "TOKEN_PARALLEL_USER_OP") {
+        parallelUserOpsMintNFTPayERC20();
+      } else if (argv.mode === "PARALLEL_USER_OP") {
+        parallelUserOpsMintNft()
       }
       else {
         mintNft();


### PR DESCRIPTION
Added examples for sending parallel user ops using an incremental nonce key for both sponsorship and token paymaster cases